### PR TITLE
Stop defaulting Content-Type to ''

### DIFF
--- a/lib/apigatewayv2_rack/request.rb
+++ b/lib/apigatewayv2_rack/request.rb
@@ -93,7 +93,7 @@ module Apigatewayv2Rack
         'SERVER_NAME' => headers['host'] || 'unknown',
         'SERVER_PORT' => (use_x_forwarded_host && ['x-forwarded-port']&.to_i&.to_s) || '80',
         'CONTENT_LENGTH' => body.bytesize.to_s,
-        'CONTENT_TYPE' => headers['content-type'] || '',
+        'CONTENT_TYPE' => headers['content-type'],
         'REMOTE_ADDR' => source_ip,
         'rack.version' => RACK_VERSION,
         'rack.url_scheme' => (use_x_forwarded_host && headers['x-forwarded-proto']) || 'https',


### PR DESCRIPTION
When using apigatewayv2_rack with Rails, requests will always result in 406 when they do not contain a Content-Type header:

```
ActionDispatch::Http::MimeNegotiation::InvalidType (nil is not a valid MIME type)
Caused by: Mime::Type::InvalidMimeType (nil is not a valid MIME type)
```

This is because apigatewayv2_rack defaults the `CONTENT_TYPE` to an empty string when the request does not specify a Content-Type header.

https://github.com/sorah/apigatewayv2_rack/blob/2802ff3b57c5ead6923c000522c9273bf186f49d/lib/apigatewayv2_rack/request.rb#L96

```
app(dev)> Mime::Type.lookup('')
(app):1:in `<top (required)>': nil is not a valid MIME type (Mime::Type::InvalidMimeType)
```

https://github.com/rails/rails/blob/v8.0.1/actionpack/lib/action_dispatch/http/mime_negotiation.rb#L27

 If we can return nil instead of an empty string here, ActionDispatch::Request#content_mime_type would not be called, and `Mime::Type.lookup('')` would not occur.

https://github.com/rails/rails/blob/v8.0.1/actionpack/lib/action_controller/metal/params_wrapper.rb#L290-L292

I currently workaround this as follows:

```ruby
Handler = Apigatewayv2Rack.handler_from_rack_config_file(File.join(__dir__, 'config.ru')) do |env, req|
  env.delete('CONTENT_TYPE') unless env['CONTENT_TYPE'].present?
end
```