### PR TITLE
Only include lib directory in released gem

### DIFF
--- a/apigatewayv2_rack.gemspec
+++ b/apigatewayv2_rack.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/apigatewayv2_rack.gemspec
+++ b/apigatewayv2_rack.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
     end
   end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/apigatewayv2_rack.gemspec
+++ b/apigatewayv2_rack.gemspec
@@ -17,13 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/sorah/apigatewayv2_rack"
   spec.metadata["changelog_uri"] = "https://github.com/sorah/apigatewayv2_rack/blob/main/CHANGELOG.md"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
-    end
-  end
+  spec.files = Dir["lib/**/*"]
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"


### PR DESCRIPTION
Thank you for writing this wonderful gem. It works perfectly and has saved me a lot of time and complexity when creating lambdas.

I have an app that uses this gem, and it's deployed into an environment that runs periodic security scans of the code. It has raised some issues around vulnerable version of `rack` and `webrick` in the `Gemfile.lock` files in the gem.

I think these files can safely be excluded from the gem. I have updated the gemspec to only include the `lib` directory, and removed a few other settings that are not needed. I followed https://piotrmurach.com/articles/writing-a-ruby-gem-specification/ and https://guides.rubygems.org/specification-reference/ to make these changes.

Would you consider accepting this change?